### PR TITLE
Lifted concurrency

### DIFF
--- a/package.yaml
+++ b/package.yaml
@@ -46,6 +46,8 @@ library:
     - aeson-casing
     - uuid
     - async
+    - lifted-async
+    - monad-control
 
 tests:
   rocketlude-test:

--- a/src/RocketLude/Concurrent.hs
+++ b/src/RocketLude/Concurrent.hs
@@ -1,9 +1,18 @@
+{-# LANGUAGE FlexibleContexts   #-}
 module RocketLude.Concurrent 
     ( batchConcurrent
     ) where
 
 import           RocketLude
 import qualified Control.Concurrent.Async as A
+import qualified Control.Concurrent.Async.Lifted as AL
+import           Control.Monad.Trans.Control (MonadBaseControl(..))
+
+liftedBatchConcurrent :: MonadBaseControl IO m => Int -> (a -> m b) -> [a] -> m [b]
+liftedBatchConcurrent batchSize fn ts =
+    let tss = splitByInt batchSize [] ts
+        inner = AL.mapConcurrently fn
+    in concat <$> traverse inner tss
 
 batchConcurrent :: Int -> (a -> IO b) -> [a] -> IO [b]
 batchConcurrent batchSize fn ts =

--- a/src/RocketLude/Concurrent.hs
+++ b/src/RocketLude/Concurrent.hs
@@ -1,6 +1,7 @@
 {-# LANGUAGE FlexibleContexts   #-}
 module RocketLude.Concurrent 
     ( batchConcurrent
+    , liftedBatchConcurrent
     ) where
 
 import           RocketLude


### PR DESCRIPTION
version de batchConcurrent usando lifted-async para cuando la funcion a aplicar es RIO